### PR TITLE
Update docstrings for MELPA inclusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,21 @@
 # helm-comint
 
-Deprecated and not maintained package moved from Helm.
+Access Emacs command interpreter prompts through helm.
+
+You can bind this as follows in .emacs:
+
+``` emacs-lisp
+(add-hook 'comint-mode-hook
+          (lambda ()
+              (define-key comint-mode-map (kbd "M-s f") 'helm-comint-prompts-all)))
+```
+
+Or as another example you can see how [Spacemacs uses
+it](https://github.com/syl20bnr/spacemacs/blob/develop/layers/%2Btools/shell/funcs.el)
+in 'spacemacs/helm-shell-history'.
+
+helm-comint is written by Pierre Neidhardt <mail@ambrevar.xyz>. Removed from
+helm v3.9.5 core and exists as a user contrib package.
+
+See https://git.savannah.gnu.org/cgit/emacs.git/tree/lisp/comint.el
+See also https://www.masteringemacs.org/article/comint-writing-command-interpreter

--- a/helm-comint.el
+++ b/helm-comint.el
@@ -87,8 +87,8 @@ you will not have anymore separators between candidates."
 (defvar helm-comint-prompts-keymap
   (let ((map (make-sparse-keymap)))
     (set-keymap-parent map helm-map)
-    (define-key map (kbd "C-c o")   #'helm-comint-prompts-other-window)
-    (define-key map (kbd "C-c C-o") #'helm-comint-prompts-other-frame)
+    (define-key map (kbd "C-c C-o")   #'helm-comint-prompts-other-window)
+    (define-key map (kbd "C-c C-f") #'helm-comint-prompts-other-frame)
     map)
   "Keymap for `helm-comint-prompt-all'.")
 


### PR DESCRIPTION
If you would prefer to keep https://github.com/emacs-helm/helm-comint.git instead of https://github.com/BenedictHW/helm-comint.git as the canonical URL.