### PR TITLE
Fix: renamed variable helm-comint-input-ring

### DIFF
--- a/helm-comint.el
+++ b/helm-comint.el
@@ -237,7 +237,7 @@ Default action for comint history."
   (interactive)
   (when (or (derived-mode-p 'comint-mode)
             (member major-mode helm-comint-mode-list))
-    (helm :sources 'helm-source-comint-input-ring
+    (helm :sources 'helm-comint-input-ring
           :input (buffer-substring-no-properties (comint-line-beginning-position)
                                                  (pos-eol))
           :buffer "*helm comint history*")))


### PR DESCRIPTION
Variable was renamed in 08814aa89d02da23fed42b6e7a1a0cd5c164c1c2 but also need to be changed in function