### PR TITLE
* helm-comint.el: depending on emacs 25.1 to follow with helm-core

### DIFF
--- a/helm-comint.el
+++ b/helm-comint.el
@@ -5,7 +5,7 @@
 ;; Author: Pierre Neidhardt <mail@ambrevar.xyz>
 ;; Maintainer: Benedict Wang <foss@bhw.name>
 ;; Version: 0.0.1
-;; Package-Requires: ((emacs "29.1") (helm "3.9.4"))
+;; Package-Requires: ((emacs "25.1") (helm "3.9.4"))
 ;; Keywords: processes, matching
 ;; Homepage: https://github.com/benedicthw/helm-comint.git
 


### PR DESCRIPTION
Hi,

The `helm-comint.el` should follow the `helm-core.el` to dependent on the `emacs 25.1` for it was splited from helm-core repo.
https://github.com/emacs-helm/helm/blob/4ea8631540ceed540c6242309c5778b3b976d12a/helm-core.el#L8C54-L8C54

Currently the unmatched dependency will cause the `helm` work with emacs-28.1 but the `helm-comint` does not work on it.

Please help apply this patch. Thanks.